### PR TITLE
Remove `retrieval_id` as fillable column of `ShortLink` model

### DIFF
--- a/app/Http/Controllers/ShortLinkController.php
+++ b/app/Http/Controllers/ShortLinkController.php
@@ -68,7 +68,7 @@ class ShortLinkController extends Controller
                 return $alphaNum;
             };
             $retrievalIDExists = function (string $retrievalID): bool {
-                return ShortLink::where('retrieval_Id', $retrievalID)->exists();
+                return ShortLink::where('retrieval_id', $retrievalID)->exists();
             };
 
             $generatedID = $generateRandomAlphaNum();
@@ -92,20 +92,20 @@ class ShortLinkController extends Controller
         $shortLink = null;
         if (Auth::check()) {
             $shortLink = $request->user()->shortLinks()->create([
-                'retrieval_Id' => $generateRetrievalID(),
                 'target_url' => $validated['targetURL'],
                 'title' => $validated['title'],
             ]);
         } else {
             $shortLink = ShortLink::create([
-                'retrieval_Id' => $generateRetrievalID(),
                 'target_url' => $validated['targetURL'],
             ]);
         }
 
+        $shortLink->retrieval_id = $generateRetrievalID();
+        $shortLink->save();
 
         return redirect(route('short-links.index'))->with([
-            'generatedID' => $shortLink->retrieval_Id,
+            'generatedID' => $shortLink->retrieval_id,
         ]);
     }
 

--- a/app/Models/ShortLink.php
+++ b/app/Models/ShortLink.php
@@ -9,7 +9,6 @@ class ShortLink extends Model
 {
     protected $fillable = [
         'title',
-        'retrieval_Id',
         'target_url',
         'disabled',
         'deleted',

--- a/database/migrations/2025_01_13_095400_create_short_links_table.php
+++ b/database/migrations/2025_01_13_095400_create_short_links_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
             $table->string('title')->nullable();
-            $table->string('retrieval_Id')->unique();
+            $table->string('retrieval_id')->unique()->default('');
             $table->string('target_url');
             $table->boolean('disabled')->default(false);
             $table->boolean('deleted')->default(false);

--- a/resources/js/Components/ShortLink.tsx
+++ b/resources/js/Components/ShortLink.tsx
@@ -23,7 +23,7 @@ export default function ShortLink({ link }: ShortLinkProps) {
 
     const { data, setData, patch, clearErrors, reset, errors, processing } =
         useForm({
-            title: link.title ?? link.retrieval_Id,
+            title: link.title ?? link.retrieval_id,
             disabled: link.disabled,
             deleted: link.deleted,
         });
@@ -66,7 +66,7 @@ export default function ShortLink({ link }: ShortLinkProps) {
                 <div className="flex items-center justify-between">
                     <div>
                         <small className="text-sm text-gray-600">
-                            {link.retrieval_Id}
+                            {link.retrieval_id}
                         </small>
                         <small className="ml-2 text-sm text-gray-600">
                             {dayjs(link.created_at).fromNow()}
@@ -148,19 +148,19 @@ export default function ShortLink({ link }: ShortLinkProps) {
                                     <p className="text-slate-400">
                                         {link.title
                                             ? link.title
-                                            : link.retrieval_Id}
+                                            : link.retrieval_id}
                                     </p>
                                 ) : (
                                     <a
                                         ref={shortLinkAnchorRef}
                                         className="underline-offset-2 hover:text-blue-600 hover:underline"
-                                        href={`${import.meta.env.BASE_URL}${link.retrieval_Id}`}
+                                        href={`${import.meta.env.BASE_URL}${link.retrieval_id}`}
                                         target="_blank"
                                         rel="noreferrer noopener"
                                     >
                                         {link.title
                                             ? link.title
-                                            : link.retrieval_Id}
+                                            : link.retrieval_id}
                                     </a>
                                 )}
                             </div>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -11,7 +11,7 @@ export interface ShortLinkType {
     id: number;
     user_id: number;
     title: string;
-    retrieval_Id: string;
+    retrieval_id: string;
     target_url: string;
     disabled: boolean;
     deleted: boolean;


### PR DESCRIPTION
The value for `retrieval_id` column of `ShortLink` models is only generated server side, and not from submitted client forms.