### PR TITLE
Refactor: Move `retrieval_id` generation logic to `ShortLink` model's class

### DIFF
--- a/app/Http/Controllers/ShortLinkController.php
+++ b/app/Http/Controllers/ShortLinkController.php
@@ -11,11 +11,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 
 const MAX_URL_LENGTH = 2048;
-const ALPHANUMERIC_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz' .
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' .
-    '0123456789';
-
-const RETIREVAL_ID_LENGTH = 8;
 
 /**
  * Regular expression to validate URLs.
@@ -53,32 +48,6 @@ class ShortLinkController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $generateRetrievalID = function (): string {
-            $generateRandomAlphaNum = function (): string {
-                mt_srand(time());
-
-                $alphaNum = '';
-                foreach (range(1, RETIREVAL_ID_LENGTH) as $i) {
-                    $alphaNumCharsLength = strlen(ALPHANUMERIC_CHARACTERS);
-                    $randomIndex = mt_rand(0, $alphaNumCharsLength - 1);
-
-                    $alphaNum .= ALPHANUMERIC_CHARACTERS[$randomIndex];
-                }
-
-                return $alphaNum;
-            };
-            $retrievalIDExists = function (string $retrievalID): bool {
-                return ShortLink::where('retrieval_id', $retrievalID)->exists();
-            };
-
-            $generatedID = $generateRandomAlphaNum();
-            while ($retrievalIDExists($generatedID)) {
-                $generatedID = $generateRandomAlphaNum();
-            }
-
-            return $generatedID;
-        };
-
         $validated = $request->validate([
             'targetURL' => [
                 'required',
@@ -100,9 +69,6 @@ class ShortLinkController extends Controller
                 'target_url' => $validated['targetURL'],
             ]);
         }
-
-        $shortLink->retrieval_id = $generateRetrievalID();
-        $shortLink->save();
 
         return redirect(route('short-links.index'))->with([
             'generatedID' => $shortLink->retrieval_id,

--- a/app/Models/ShortLink.php
+++ b/app/Models/ShortLink.php
@@ -7,6 +7,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+const ALPHANUMERIC_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz' .
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' .
+    '0123456789';
+
+const RETIREVAL_ID_LENGTH = 8;
+
 class ShortLink extends Model
 {
     protected $fillable = [
@@ -15,6 +21,15 @@ class ShortLink extends Model
         'disabled',
         'deleted',
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function (ShortLink $model) {
+            $model->retrieval_id = $model->generateRetrievalID();
+        });
+    }
 
     public function user(): BelongsTo
     {
@@ -25,5 +40,32 @@ class ShortLink extends Model
     {
         $this->increment('clicks');
         $this->save();
+    }
+
+    private function generateRetrievalID(): string
+    {
+        $generateRandomAlphaNum = function (): string {
+            mt_srand(time());
+
+            $alphaNum = '';
+            foreach (range(1, RETIREVAL_ID_LENGTH) as $i) {
+                $alphaNumCharsLength = strlen(ALPHANUMERIC_CHARACTERS);
+                $randomIndex = mt_rand(0, $alphaNumCharsLength - 1);
+
+                $alphaNum .= ALPHANUMERIC_CHARACTERS[$randomIndex];
+            }
+
+            return $alphaNum;
+        };
+        $retrievalIDExists = function (string $retrievalID): bool {
+            return ShortLink::where('retrieval_id', $retrievalID)->exists();
+        };
+
+        $generatedID = $generateRandomAlphaNum();
+        while ($retrievalIDExists($generatedID)) {
+            $generatedID = $generateRandomAlphaNum();
+        }
+
+        return $generatedID;
     }
 }


### PR DESCRIPTION
# Refactor: Move `retrieval_id` generation logic to `ShortLink` model's class

## Description

Refactors the application by moving the logic for generating the retrieval ID of a `ShortLink` model upon creation from the controller to the model's class instead.

This change centralizes the logic within the model, improving code organization and maintainability.