### PR TITLE
Set `preserveScroll` to true on every http calls

### DIFF
--- a/resources/js/Components/ShortLink.tsx
+++ b/resources/js/Components/ShortLink.tsx
@@ -39,12 +39,14 @@ export default function ShortLink({ link }: ShortLinkProps) {
             onBefore: () => {
                 data.disabled = !data.disabled;
             },
+            preserveScroll: true,
         });
     };
     const submit = (e: FormEvent) => {
         e.preventDefault();
         patch(route('short-links.update', link.id), {
             onSuccess: () => setEditing(false),
+            preserveScroll: true,
         });
     };
 
@@ -92,6 +94,7 @@ export default function ShortLink({ link }: ShortLinkProps) {
                                     as="button"
                                     href={route('short-links.destroy', link.id)}
                                     method="delete"
+                                    preserveScroll
                                 >
                                     Delete
                                 </Dropdown.Link>

--- a/resources/js/Components/ShortLinkCreateForm.tsx
+++ b/resources/js/Components/ShortLinkCreateForm.tsx
@@ -29,7 +29,10 @@ function ShortLinkCreateForm({
 
     const submit = (e: FormEvent) => {
         e.preventDefault();
-        post(route('short-links.store'));
+        post(route('short-links.store'), {
+            preserveScroll: true,
+            preserveState: true,
+        });
     };
 
     return (


### PR DESCRIPTION
When navigating between pages or making form operations, Inertia mimics default browser behavior by automatically resetting the scroll position of the document body (as well as any scroll regions you've defined) back to the top.

This change prevents scroll resets whenever the user interacts with the form.