### PR TITLE
Prevent back button from loading cached page

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -26,3 +26,8 @@ createInertiaApp({
         color: '#4B5563',
     },
 });
+
+window.addEventListener('popstate', (event) => {
+    event.stopImmediatePropagation();
+    window.location.reload();
+});


### PR DESCRIPTION
## Prevent back button from loading cached page

### Description
This pull request addresses an issue where navigating to the previous page using the back button always loads cached content. By reloading the page on every `popstate` event, we ensure that the latest content is fetched from the server.

### Changes
- Implemented a reload on every `popstate` event to ensure the latest content is always loaded from the server.
- This change guarantees that the routing behaviors defined in the backend are enforced. For example, it prevents unauthorized users from accessing the dashboard by pressing the back button after logging out.

### Benefits
- Ensures that users always see the most up-to-date content.
- Enforces backend routing rules, improving security and user experience.